### PR TITLE
Add configurable speed options for visual effects

### DIFF
--- a/src/nms.c
+++ b/src/nms.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <string.h>
 #include "nmseffect.h"
 #include "input.h"
 #include "error.h"
@@ -22,7 +23,7 @@ int main(int argc, char *argv[])
 
 	input = NULL;
 
-	while ((o = getopt(argc, argv, "f:ascv")) != -1)
+	while ((o = getopt(argc, argv, "f:ascvt:j:J:r:h")) != -1)
 	{
 		switch (o)
 		{
@@ -38,8 +39,34 @@ int main(int argc, char *argv[])
 			case 'c':
 				nmseffect_set_clearscr(1);
 				break;
+			case 't':
+				nmseffect_set_type_speed(atoi(optarg));
+				break;
+			case 'j':
+				nmseffect_set_jumble_seconds(atoi(optarg));
+				break;
+			case 'J':
+				nmseffect_set_jumble_speed(atoi(optarg));
+				break;
+			case 'r':
+				nmseffect_set_reveal_speed(atoi(optarg));
+				break;
 			case 'v':
 				printf("nms version " VERSION "\n");
+				return EXIT_SUCCESS;
+			case 'h':
+				printf("Usage: nms [OPTIONS]\n\n");
+				printf("Options:\n");
+				printf("  -f COLOR\tSet foreground color (white, yellow, magenta, blue, green, red, cyan)\n");
+				printf("  -a\t\tAuto-decrypt (no key press required)\n");
+				printf("  -s\t\tMask blank spaces\n");
+				printf("  -c\t\tClear screen before showing output\n");
+				printf("  -t MS\t\tSet type effect speed (milliseconds per character, default: 4)\n");
+				printf("  -j SEC\tSet jumble effect duration (seconds, default: 2)\n");
+				printf("  -J MS\t\tSet jumble effect speed (milliseconds per update, default: 35)\n");
+				printf("  -r MS\t\tSet reveal effect speed (milliseconds per update, default: 50)\n");
+				printf("  -v\t\tDisplay version information\n");
+				printf("  -h\t\tDisplay this help message\n");
 				return EXIT_SUCCESS;
 			case '?':
 				if (isprint(optopt))

--- a/src/nmseffect.c
+++ b/src/nmseffect.c
@@ -25,11 +25,11 @@
 #include "nmstermio.h"
 #include "nmscharset.h"
 
-// Speed settings
-#define TYPE_EFFECT_SPEED    4     // miliseconds per char
-#define JUMBLE_SECONDS       2     // number of seconds for jumble effect
-#define JUMBLE_LOOP_SPEED    35    // miliseconds between each jumble
-#define REVEAL_LOOP_SPEED    50    // miliseconds between each reveal loop
+// Speed settings (now configurable)
+static int TYPE_EFFECT_SPEED    = 4;     // miliseconds per char
+static int JUMBLE_SECONDS       = 2;     // number of seconds for jumble effect
+static int JUMBLE_LOOP_SPEED    = 35;    // miliseconds between each jumble
+static int REVEAL_LOOP_SPEED    = 50;    // miliseconds between each reveal loop
 
 // Behavior settings
 static int autoDecrypt      = 0;            // Auto-decrypt flag
@@ -340,11 +340,44 @@ void nmseffect_set_clearscr(int setting) {
  * do not support color. Though, compiling with ncurses support is perhaps
  * a better option, as it will detect color capabilities automatically.
  */
-void nmseffect_set_color(int setting) {
+void nmseffect_use_color(int setting) {
 	if (setting)
 		colorOn = 1;
 	else
 		colorOn = 0;
+}
+
+/*
+ * Set the TYPE_EFFECT_SPEED value. This controls how fast the characters
+ * are initially displayed on the screen (milliseconds per character).
+ */
+void nmseffect_set_type_speed(int speed) {
+	if (speed > 0)
+		TYPE_EFFECT_SPEED = speed;
+}
+
+/*
+ * Set the number of seconds the jumble effect will run.
+ */
+void nmseffect_set_jumble_seconds(int seconds) {
+	if (seconds >= 0)
+		JUMBLE_SECONDS = seconds;
+}
+
+/*
+ * Set the speed of the jumble effect (milliseconds between updates).
+ */
+void nmseffect_set_jumble_speed(int speed) {
+	if (speed > 0)
+		JUMBLE_LOOP_SPEED = speed;
+}
+
+/*
+ * Set the speed of the reveal effect (milliseconds between updates).
+ */
+void nmseffect_set_reveal_speed(int speed) {
+	if (speed > 0)
+		REVEAL_LOOP_SPEED = speed;
 }
 
 /*

--- a/src/nmseffect.h
+++ b/src/nmseffect.h
@@ -17,5 +17,9 @@ void nmseffect_set_maskblank(int);
 void nmseffect_set_clearscr(int);
 void nmseffect_use_color(int);
 void nmseffect_set_input_position(int, int);
+void nmseffect_set_type_speed(int);
+void nmseffect_set_jumble_seconds(int);
+void nmseffect_set_jumble_speed(int);
+void nmseffect_set_reveal_speed(int);
 
 #endif

--- a/src/sneakers.c
+++ b/src/sneakers.c
@@ -8,10 +8,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+#include <ctype.h>
 #include <sys/ioctl.h>
 #include "nmseffect.h"
 
-int main(void) {
+#define VERSION "1.0.1"
+
+int main(int argc, char *argv[]) {
+	int o;
 	int termCols, spaces = 0;
 	unsigned char *display_uc = NULL;
 	char *display        = NULL;
@@ -29,6 +34,60 @@ int main(void) {
 	char *menu6          = "[6] Remote Operator Logon/Logoff";
 	char *foot1Center    = "================================================================";
 	char *foot2Center    = "[ ] Select Option or ESC to Abort";
+	
+	// Process command line options
+	while ((o = getopt(argc, argv, "f:ascvt:j:J:r:h")) != -1) {
+		switch (o) {
+			case 'f':
+				nmseffect_set_foregroundcolor(optarg);
+				break;
+			case 'a':
+				nmseffect_set_autodecrypt(1);
+				break;
+			case 's':
+				nmseffect_set_maskblank(1);
+				break;
+			case 'c':
+				nmseffect_set_clearscr(1);
+				break;
+			case 't':
+				nmseffect_set_type_speed(atoi(optarg));
+				break;
+			case 'j':
+				nmseffect_set_jumble_seconds(atoi(optarg));
+				break;
+			case 'J':
+				nmseffect_set_jumble_speed(atoi(optarg));
+				break;
+			case 'r':
+				nmseffect_set_reveal_speed(atoi(optarg));
+				break;
+			case 'v':
+				printf("sneakers version " VERSION "\n");
+				return EXIT_SUCCESS;
+			case 'h':
+				printf("Usage: sneakers [OPTIONS]\n\n");
+				printf("Options:\n");
+				printf("  -f COLOR\tSet foreground color (white, yellow, magenta, blue, green, red, cyan)\n");
+				printf("  -a\t\tAuto-decrypt (no key press required)\n");
+				printf("  -s\t\tMask blank spaces\n");
+				printf("  -c\t\tClear screen before showing output\n");
+				printf("  -t MS\t\tSet type effect speed (milliseconds per character, default: 4)\n");
+				printf("  -j SEC\tSet jumble effect duration (seconds, default: 2)\n");
+				printf("  -J MS\t\tSet jumble effect speed (milliseconds per update, default: 35)\n");
+				printf("  -r MS\t\tSet reveal effect speed (milliseconds per update, default: 50)\n");
+				printf("  -v\t\tDisplay version information\n");
+				printf("  -h\t\tDisplay this help message\n");
+				return EXIT_SUCCESS;
+			case '?':
+				if (isprint(optopt)) {
+					fprintf(stderr, "Unknown option '-%c'.\n", optopt);
+				} else {
+					fprintf(stderr, "Unknown option character '\\x%x'.\n", optopt);
+				}
+				return EXIT_FAILURE;
+		}
+	}
 
 	// Get terminal dimentions (needed for centering)
 	struct winsize w;
@@ -180,6 +239,7 @@ int main(void) {
 	}
 	strcat(display, foot2Center);
 
+	// Default setting for sneakers is to clear the screen
 	nmseffect_set_clearscr(1);
 
 	memcpy(display_uc, display, 20 * termCols);


### PR DESCRIPTION
## Summary
- Add command-line options to customize the speed of visual effects
- Implement configurable type, jumble, and reveal speeds
- Make both nms and sneakers commands support the new options

## Test plan
- Run `nms -h` and `sneakers -h` to verify new options appear in help
- Test each option to confirm they affect the visual effects as expected
- Verify default behavior remains unchanged when no options are provided

🤖 Generated with [Claude Code](https://claude.ai/code)